### PR TITLE
Add optional public evidence links and hide local paths

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -22,6 +22,7 @@
   - `reproSteps`
 - [ ] Claim is atomic (one behavior per claim).
 - [ ] Evidence paths and repro steps are concrete enough for another reviewer to verify.
+- [ ] Added `evidence.publicUrl` where a public artifact is available.
 - [ ] If replacing older knowledge, `status`/`supersedes`/`supersededBy` are updated.
 
 ## Validation

--- a/.github/workflows/validate-claims-schema.yml
+++ b/.github/workflows/validate-claims-schema.yml
@@ -1,0 +1,37 @@
+name: Claims Schema
+
+on:
+  pull_request:
+    paths:
+      - "src/content/rcp-claims/**"
+      - "src/content.config.ts"
+      - "src/pages/research/**"
+      - "docs/rcp-research-notes.md"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/content/rcp-claims/**"
+      - "src/content.config.ts"
+      - "src/pages/research/**"
+      - "docs/rcp-research-notes.md"
+
+jobs:
+  validate-claims:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate claims via Astro build
+        run: npm run build

--- a/.github/workflows/validate-rcp-claims.yml
+++ b/.github/workflows/validate-rcp-claims.yml
@@ -1,4 +1,4 @@
-name: Validate RCP Claims
+name: Site Build
 
 on:
   pull_request:
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  validate:
+  build:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,5 +23,5 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build site (includes content schema validation)
+      - name: Build site
         run: npm run build

--- a/docs/rcp-research-notes.md
+++ b/docs/rcp-research-notes.md
@@ -29,6 +29,7 @@ reproSteps:
 evidence:
   - type: diff
     path: /absolute/or/repo/path
+    publicUrl: https://example.com/evidence/diff.txt
     note: optional
 supersedes: []
 supersededBy:
@@ -42,6 +43,8 @@ supersededBy:
 - `status`: `confirmed`, `disputed`, `superseded`
 
 `summary` is required and should be a short reviewer-facing synopsis.
+`publicUrl` is optional for evidence artifacts that are publicly reachable.
+Absolute local `path` values are kept for provenance but are not exposed verbatim on public pages.
 
 ## Component ID Source
 

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -29,6 +29,7 @@ const rcpClaims = defineCollection({
 				z.object({
 					type: z.enum(["fixture", "diff", "screenshot", "log", "doc"]),
 					path: z.string().min(1),
+					publicUrl: z.string().url().optional(),
 					note: z.string().optional(),
 				}),
 			)

--- a/src/pages/research/[...slug].astro
+++ b/src/pages/research/[...slug].astro
@@ -18,7 +18,12 @@ function formatDate(date: Date): string {
 }
 
 function isAbsoluteLocalPath(path: string): boolean {
-	return path.startsWith("/");
+	return (
+		path.startsWith("/") ||
+		/^[a-zA-Z]:[\\/]/.test(path) ||
+		path.startsWith("\\\\") ||
+		path.startsWith("file://")
+	);
 }
 ---
 

--- a/src/pages/research/[...slug].astro
+++ b/src/pages/research/[...slug].astro
@@ -16,6 +16,10 @@ const { Content } = await render(claim);
 function formatDate(date: Date): string {
 	return date.toISOString().slice(0, 10);
 }
+
+function isAbsoluteLocalPath(path: string): boolean {
+	return path.startsWith("/");
+}
 ---
 
 <Base title={`RCP Claim · ${claim.data.componentId}`} description={claim.data.summary}>
@@ -56,10 +60,31 @@ function formatDate(date: Date): string {
 		<section class="claim-section">
 			<h2>Evidence</h2>
 			<ul class="evidence-list">
-				{claim.data.evidence.map((item: { type: string; path: string; note?: string }) => (
+				{claim.data.evidence.map((item: {
+					type: string;
+					path: string;
+					publicUrl?: string;
+					note?: string;
+				}) => (
 					<li>
 						<div><strong>{item.type}</strong></div>
-						<div><code>{item.path}</code></div>
+						{
+							item.publicUrl ? (
+								<div>
+									<a href={item.publicUrl} target="_blank" rel="noopener noreferrer">
+										open evidence ↗
+									</a>
+								</div>
+							) : isAbsoluteLocalPath(item.path) ? (
+								<div>
+									<em>local-only evidence path (not publicly exposed)</em>
+								</div>
+							) : (
+								<div>
+									<code>{item.path}</code>
+								</div>
+							)
+						}
 						{item.note && <p>{item.note}</p>}
 					</li>
 				))}
@@ -125,6 +150,15 @@ function formatDate(date: Date): string {
 	.evidence-list code,
 	.meta-list code {
 		overflow-wrap: anywhere;
+	}
+
+	.evidence-list a {
+		color: var(--ios);
+		text-decoration: none;
+	}
+
+	.evidence-list a:hover {
+		text-decoration: underline;
 	}
 
 	.prose :global(p),


### PR DESCRIPTION
## Summary

- What claim(s) are being added or updated?
- Which component(s) are affected?

## RCP Research Note Checklist

- [ ] Added or updated Markdown claim file(s) under `src/content/rcp-claims/`.
- [ ] `componentId` matches an existing ID from `src/data/features/realitykit-components.json`.
- [ ] All mandatory fields are present:
  - `claim`
  - `summary`
  - `scope`
  - `evidence`
  - `sourceType`
  - `confidence`
  - `status`
  - `author`
  - `date`
  - `rcpVersion`
  - `xcodeBuild`
  - `reproSteps`
- [ ] Claim is atomic (one behavior per claim).
- [ ] Evidence paths and repro steps are concrete enough for another reviewer to verify.
- [ ] If replacing older knowledge, `status`/`supersedes`/`supersededBy` are updated.

## Validation

- [ ] Ran `npm run build` locally.
