### PR TITLE
Add claim contribution entry points and research index

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,7 @@
 - [ ] Claim is atomic (one behavior per claim).
 - [ ] Evidence paths and repro steps are concrete enough for another reviewer to verify.
 - [ ] Added `evidence.publicUrl` where a public artifact is available.
+- [ ] Added `evidence.artifactLabel` for clearer evidence names in UI.
 - [ ] If replacing older knowledge, `status`/`supersedes`/`supersededBy` are updated.
 
 ## Validation

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Currently covers **62 public RealityKit `Component` types** from Xcode 26.3 RC w
 - New in 26.0 callouts (7 components)
 
 Also includes a PR-driven **RCP reverse-engineering claims** domain for authored behavior discoveries, separate from API availability tables.
+Browse claims at `/research` on the site.
 
 ## Data source
 

--- a/docs/rcp-research-notes.md
+++ b/docs/rcp-research-notes.md
@@ -29,6 +29,7 @@ reproSteps:
 evidence:
   - type: diff
     path: /absolute/or/repo/path
+    artifactLabel: USDA diff bundle
     publicUrl: https://example.com/evidence/diff.txt
     note: optional
 supersedes: []
@@ -44,6 +45,7 @@ supersededBy:
 
 `summary` is required and should be a short reviewer-facing synopsis.
 `publicUrl` is optional for evidence artifacts that are publicly reachable.
+`artifactLabel` is optional and improves evidence readability in UI.
 Absolute local `path` values are kept for provenance but are not exposed verbatim on public pages.
 
 ## Component ID Source

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -29,6 +29,7 @@ const rcpClaims = defineCollection({
 				z.object({
 					type: z.enum(["fixture", "diff", "screenshot", "log", "doc"]),
 					path: z.string().min(1),
+					artifactLabel: z.string().optional(),
 					publicUrl: z.string().url().optional(),
 					note: z.string().optional(),
 				}),

--- a/src/content/rcp-claims/ambient-audio/ambient-audio-preview-resource-not-directly-authored.md
+++ b/src/content/rcp-claims/ambient-audio/ambient-audio-preview-resource-not-directly-authored.md
@@ -1,0 +1,30 @@
+---
+componentId: ambient-audio-component
+claim: AmbientAudio Preview Resource selection is not authored directly on the AmbientAudio component in current fixtures.
+summary: Resource choice appears in AudioLibrary resources plus RealityKitAudioFile prims, while AmbientAudio keeps only component-local fields like gain.
+scope: USDA authored
+sourceType: direct-diff
+confidence: high
+status: confirmed
+author: elkraneo
+date: 2026-02-19
+rcpVersion: "26.3 RC"
+xcodeBuild: "26.2 SDK era (from fixture notes)"
+reproSteps:
+  - Open Ambient Audio BASE fixture in ComponentFieldExploration.
+  - Set Preview Resource in RCP and save as Resource fixture variant.
+  - Diff BASE vs Resource USDA.
+  - Verify changes land in AudioLibrary and RealityKitAudioFile prims, not on AmbientAudio as a direct resource field.
+evidence:
+  - type: doc
+    artifactLabel: Audio relationship deep dive
+    path: /Volumes/Plutonian/_Developer/Deconstructed/source/Deconstructed/Docs/Audio-Component-Library-Relationship.md
+    note: Ambient Audio section documents BASE vs Resource authored deltas.
+  - type: fixture
+    artifactLabel: ComponentFieldExploration fixture root
+    path: /Volumes/Plutonian/_Developer/Deconstructed/references/ComponentFieldExploration
+    note: Includes Ambient Audio BASE and Resource fixture files used in diffing.
+supersedes: []
+---
+
+This claim reflects current fixture evidence and should be re-validated when new RCP/Xcode versions are sampled.

--- a/src/content/rcp-claims/input-target/input-target-allowed-input-direct-authored.md
+++ b/src/content/rcp-claims/input-target/input-target-allowed-input-direct-authored.md
@@ -1,0 +1,30 @@
+---
+componentId: input-target-component
+claim: InputTarget with Allowed Input = Direct authors `allowsDirectInput = 1` and `allowsIndirectInput = 0`.
+summary: Fixture deltas show Direct mode serializes as explicit booleans on the InputTarget component prim.
+scope: USDA authored
+sourceType: direct-diff
+confidence: high
+status: confirmed
+author: elkraneo
+date: 2026-02-19
+rcpVersion: "26.3 RC"
+xcodeBuild: "26.2 SDK era (from fixture notes)"
+reproSteps:
+  - Open the Input Target fixture in ComponentFieldExploration.
+  - Set Allowed Input to Direct.
+  - Save and diff USDA against the base fixture.
+  - Verify `allowsDirectInput = 1` and `allowsIndirectInput = 0` on `RealityKit.InputTarget`.
+evidence:
+  - type: doc
+    artifactLabel: Inspector verified field matrix
+    path: /Volumes/Plutonian/_Developer/Deconstructed/source/Deconstructed/Docs/Inspector-Verified-Field-Matrix.md
+    note: Section "RealityKit.InputTarget" documents authored deltas for Allowed Input modes.
+  - type: fixture
+    artifactLabel: ComponentFieldExploration fixture root
+    path: /Volumes/Plutonian/_Developer/Deconstructed/references/ComponentFieldExploration
+    note: Contains AllowedInput base/direct/indirect fixture variants.
+supersedes: []
+---
+
+This claim is scoped to authored scene data only and does not assert runtime interaction behavior.

--- a/src/pages/features/[slug].astro
+++ b/src/pages/features/[slug].astro
@@ -122,6 +122,29 @@ const correctionParams = new URLSearchParams({
 const suggestCorrectionUrl = `https://github.com/elkraneo/uncannyuse/issues/new?${correctionParams.toString()}`;
 const suggestResourceIssueUrl =
 	"https://github.com/elkraneo/uncannyuse/issues/new?template=resource_suggestion.yml";
+const claimBody = [
+	"## Component",
+	`${feature.name} (${feature.id})`,
+	"",
+	"## Proposed claim (atomic)",
+	"- ",
+	"",
+	"## Scope",
+	"- [ ] RCP UI",
+	"- [ ] USDA authored",
+	"- [ ] runtime behavior",
+	"",
+	"## Evidence",
+	"- ",
+	"",
+	"## Repro steps",
+	"1. ",
+].join("\n");
+const suggestClaimParams = new URLSearchParams({
+	title: `[claim] ${feature.name}`,
+	body: claimBody,
+});
+const suggestClaimIssueUrl = `https://github.com/elkraneo/uncannyuse/issues/new?${suggestClaimParams.toString()}`;
 const notesList = feature.notes ?? [];
 const rcpStatusText = feature.rcp
 	? "In Add Component menu"
@@ -348,6 +371,17 @@ function formatClaimValue(
 					<p class="notes-empty">No RCP reverse-engineering claims yet.</p>
 				)
 			}
+			<div class="claim-actions">
+				<a href="/research/" class="claim-action-link">browse all claims</a>
+				<a
+					href={suggestClaimIssueUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="claim-action-link"
+				>
+					propose claim ↗
+				</a>
+			</div>
 		</section>
 
 		<!-- Notes + Resources -->
@@ -916,6 +950,27 @@ function formatClaimValue(
 
 	.claim-link:hover {
 		text-decoration: underline;
+	}
+
+	.claim-actions {
+		margin-top: 0.8rem;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.6rem;
+	}
+
+	.claim-action-link {
+		font-size: 0.8125rem;
+		color: var(--muted);
+		text-decoration: none;
+		border: 1px solid var(--border);
+		border-radius: 5px;
+		padding: 0.22rem 0.5rem;
+	}
+
+	.claim-action-link:hover {
+		color: var(--text);
+		background: var(--surface-up);
 	}
 
 	/* Notes */

--- a/src/pages/research/[...slug].astro
+++ b/src/pages/research/[...slug].astro
@@ -68,11 +68,14 @@ function isAbsoluteLocalPath(path: string): boolean {
 				{claim.data.evidence.map((item: {
 					type: string;
 					path: string;
+					artifactLabel?: string;
 					publicUrl?: string;
 					note?: string;
 				}) => (
 					<li>
-						<div><strong>{item.type}</strong></div>
+						<div>
+							<strong>{item.artifactLabel ?? item.type}</strong>
+						</div>
 						{
 							item.publicUrl ? (
 								<div>

--- a/src/pages/research/index.astro
+++ b/src/pages/research/index.astro
@@ -1,0 +1,186 @@
+---
+import { getCollection } from "astro:content";
+import Base from "../../layouts/Base.astro";
+
+const claims = (await getCollection("rcp-claims")).sort(
+	(a, b) => b.data.date.getTime() - a.data.date.getTime(),
+);
+
+const groups = new Map<string, typeof claims>();
+for (const claim of claims) {
+	const existing = groups.get(claim.data.componentId) ?? [];
+	existing.push(claim);
+	groups.set(claim.data.componentId, existing);
+}
+
+const groupedClaims = [...groups.entries()].sort((a, b) =>
+	a[0].localeCompare(b[0]),
+);
+const proposeClaimUrl =
+	"https://github.com/elkraneo/uncannyuse/issues/new?title=%5Bclaim%5D%20&body=%23%23%20Component%0A-%20%0A%0A%23%23%20Proposed%20claim%20(atomic)%0A-%20%0A%0A%23%23%20Scope%0A-%20%5B%20%5D%20RCP%20UI%0A-%20%5B%20%5D%20USDA%20authored%0A-%20%5B%20%5D%20runtime%20behavior%0A%0A%23%23%20Evidence%0A-%20%0A%0A%23%23%20Repro%20steps%0A1.%20";
+
+function formatDate(date: Date): string {
+	return date.toISOString().slice(0, 10);
+}
+---
+
+<Base
+	title="RCP Research Claims"
+	description="Reverse-engineering claim index for Reality Composer Pro behavior."
+>
+	<article class="research-page">
+		<header class="research-header">
+			<h1>RCP Reverse-Engineering Claims</h1>
+			<p>
+				Evidence-backed behavior claims grouped by component. Open any claim for
+				full metadata, repro steps, and evidence.
+			</p>
+			<div class="research-actions">
+				<a href={proposeClaimUrl} target="_blank" rel="noopener noreferrer">
+					propose claim ↗
+				</a>
+			</div>
+		</header>
+
+		{
+			groupedClaims.map(([componentId, entries]) => (
+				<section class="claim-group">
+					<h2>
+						<a href={`/features/${componentId}`}>{componentId}</a>
+						<span>{entries.length} claim{entries.length > 1 ? "s" : ""}</span>
+					</h2>
+					<ul class="claim-list">
+						{entries.map((claim) => (
+							<li class="claim-item">
+								<a href={`/research/${claim.slug}/`} class="claim-title">
+									{claim.data.claim}
+								</a>
+								<p>{claim.data.summary}</p>
+								<div class="claim-meta">
+									<span>{claim.data.status}</span>
+									<span>{claim.data.confidence}</span>
+									<span>{claim.data.scope}</span>
+									<span>{formatDate(claim.data.date)}</span>
+								</div>
+							</li>
+						))}
+					</ul>
+				</section>
+			))
+		}
+	</article>
+</Base>
+
+<style>
+	.research-page {
+		max-width: 900px;
+		margin: 0 auto;
+		padding: 2rem 1.5rem 5rem;
+	}
+
+	.research-header h1 {
+		font-size: clamp(1.6rem, 3vw, 2.2rem);
+	}
+
+	.research-header p {
+		margin-top: 0.6rem;
+		color: var(--muted);
+		max-width: 65ch;
+	}
+
+	.research-actions {
+		margin-top: 0.75rem;
+	}
+
+	.research-actions a {
+		font-size: 0.8125rem;
+		color: var(--muted);
+		text-decoration: none;
+		border: 1px solid var(--border);
+		border-radius: 5px;
+		padding: 0.22rem 0.5rem;
+	}
+
+	.research-actions a:hover {
+		color: var(--text);
+		background: var(--surface-up);
+	}
+
+	.claim-group {
+		margin-top: 1.5rem;
+		padding-top: 1rem;
+		border-top: 1px solid var(--border);
+	}
+
+	.claim-group h2 {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.6rem;
+		align-items: center;
+		font-size: 1rem;
+	}
+
+	.claim-group h2 a {
+		color: var(--text);
+		text-decoration: none;
+	}
+
+	.claim-group h2 a:hover {
+		text-decoration: underline;
+	}
+
+	.claim-group h2 span {
+		font-size: 0.8rem;
+		color: var(--muted);
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		padding: 0.1rem 0.45rem;
+	}
+
+	.claim-list {
+		list-style: none;
+		display: flex;
+		flex-direction: column;
+		gap: 0.7rem;
+		margin-top: 0.8rem;
+	}
+
+	.claim-item {
+		border: 1px solid var(--border);
+		border-radius: 8px;
+		padding: 0.7rem 0.8rem;
+		background: var(--surface);
+	}
+
+	.claim-title {
+		color: var(--text);
+		text-decoration: none;
+		font-weight: 500;
+	}
+
+	.claim-title:hover {
+		color: var(--ios);
+		text-decoration: underline;
+	}
+
+	.claim-item p {
+		margin-top: 0.35rem;
+		color: var(--muted);
+		font-size: 0.9rem;
+	}
+
+	.claim-meta {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.35rem;
+		margin-top: 0.55rem;
+	}
+
+	.claim-meta span {
+		font-size: 0.75rem;
+		color: var(--muted);
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		padding: 0.1rem 0.45rem;
+	}
+</style>


### PR DESCRIPTION
## Summary

- What claim(s) are being added or updated?
- Which component(s) are affected?

## RCP Research Note Checklist

- [ ] Added or updated Markdown claim file(s) under `src/content/rcp-claims/`.
- [ ] `componentId` matches an existing ID from `src/data/features/realitykit-components.json`.
- [ ] All mandatory fields are present:
  - `claim`
  - `summary`
  - `scope`
  - `evidence`
  - `sourceType`
  - `confidence`
  - `status`
  - `author`
  - `date`
  - `rcpVersion`
  - `xcodeBuild`
  - `reproSteps`
- [ ] Claim is atomic (one behavior per claim).
- [ ] Evidence paths and repro steps are concrete enough for another reviewer to verify.
- [ ] Added `evidence.publicUrl` where a public artifact is available.
- [ ] If replacing older knowledge, `status`/`supersedes`/`supersededBy` are updated.

## Validation

- [ ] Ran `npm run build` locally.
